### PR TITLE
[PMK-5007] Add support for roles-as-groups in keystone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ fix: ## Fix lint violations
 
 .PHONY: docker-image
 docker-image:
-	@sudo docker build -t $(DOCKER_IMAGE) .
+	docker build -t $(DOCKER_IMAGE) .
 
 .PHONY: verify-proto
 verify-proto: proto


### PR DESCRIPTION
This PR adds a couple of roles:
* option to load roles as groups in the keystone connector
* option to configure group filters, including the mapping of groups.