### PR TITLE
Fix go vcs issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,8 @@ bin/example-app:
 .PHONY: release-binary
 release-binary: LD_FLAGS = "-w -X main.version=$(VERSION) -extldflags \"-static\""
 release-binary: generate
-	@go build -o /go/bin/dex -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
-	@go build -o /go/bin/docker-entrypoint -v -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/docker-entrypoint
+	@go build -o /go/bin/dex -v -buildvcs=false -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/dex
+	@go build -o /go/bin/docker-entrypoint -v -buildvcs=false -ldflags $(LD_FLAGS) $(REPO_PATH)/cmd/docker-entrypoint
 
 docker-compose.override.yaml:
 	cp docker-compose.override.yaml.dist docker-compose.override.yaml


### PR DESCRIPTION
Some minor improvements to make Dex work with our CI. 
* The `-buildvcs=false` was needed because it would fail otherwise on missing git info. This might have to do with the version of Docker on our builders, because it was working fine on my local machine. For practical reasons, fixing it like this.