### PR TITLE
KAAP-712:Add customername in keystone config , KAAP-295: replace "_" with "-" in group names

### DIFF
--- a/connector/keystone/keystone.go
+++ b/connector/keystone/keystone.go
@@ -4,6 +4,7 @@ package keystone
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -64,10 +65,11 @@ type domainKeystone struct {
 //			keystonePassword: DEMO_PASS
 //			useRolesAsGroups: true
 type Config struct {
-	Domain        string `json:"domain"`
-	Host          string `json:"keystoneHost"`
-	AdminUsername string `json:"keystoneUsername"`
-	AdminPassword string `json:"keystonePassword"`
+	Domain             string `json:"domain"`
+	Host               string `json:"keystoneHost"`
+	AdminUsername      string `json:"keystoneUsername"`
+	AdminPassword      string `json:"keystonePassword"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
 }
 
 type loginRequestData struct {
@@ -177,13 +179,19 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 	domain := domainKeystone{
 		Name: c.Domain,
 	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: c.InsecureSkipVerify,
+		},
+	}
+	client := &http.Client{Transport: tr}
 	return &conn{
 		Domain:        domain,
 		Host:          c.Host,
 		AdminUsername: c.AdminUsername,
 		AdminPassword: c.AdminPassword,
 		Logger:        logger,
-		client:        http.DefaultClient,
+		client:        client,
 	}, nil
 }
 

--- a/connector/keystone/keystone.go
+++ b/connector/keystone/keystone.go
@@ -187,9 +187,6 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		},
 	}
 	client := &http.Client{Transport: tr}
-	if c.CustomerName == "" {
-		return nil, fmt.Errorf("customerName is required in keystone config it cannot be empty")
-	}
 	return &conn{
 		Domain:        domain,
 		Host:          c.Host,
@@ -552,9 +549,14 @@ func (p *conn) getGroups(ctx context.Context, token string, tokenInfo *tokenInfo
 	var roleGroups []string
 
 	// get the customer name to be prefixed in the group name
-	// hostName, err := p.getHostname()
 	customerName := p.CustomerName
-
+	// if customerName is not provided in the keystone config get it from keystone host url.
+	if customerName == "" {
+		customerName, err = p.getHostname()
+		if err != nil {
+			return userGroups, err
+		}
+	}
 	for _, roleAssignment := range roleAssignments {
 		role, ok := roleMap[roleAssignment.Role.ID]
 		if !ok {

--- a/connector/keystone/keystone.go
+++ b/connector/keystone/keystone.go
@@ -23,6 +23,7 @@ type conn struct {
 	AdminPassword string
 	client        *http.Client
 	Logger        log.Logger
+	fqdn          string
 }
 
 // type group struct {
@@ -70,6 +71,7 @@ type Config struct {
 	AdminUsername      string `json:"keystoneUsername"`
 	AdminPassword      string `json:"keystonePassword"`
 	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+	Fqdn               string `json:"fqdn"`
 }
 
 type loginRequestData struct {
@@ -192,6 +194,7 @@ func (c *Config) Open(id string, logger log.Logger) (connector.Connector, error)
 		AdminPassword: c.AdminPassword,
 		Logger:        logger,
 		client:        client,
+		fqdn:          c.Fqdn,
 	}, nil
 }
 
@@ -546,10 +549,9 @@ func (p *conn) getGroups(ctx context.Context, token string, tokenInfo *tokenInfo
 	var roleGroups []string
 
 	// get the customer name to be prefixed in the group name
-	hostName, err := p.getHostname()
-	if err != nil {
-		return userGroups, err
-	}
+	// hostName, err := p.getHostname()
+	hostName := p.fqdn
+
 	for _, roleAssignment := range roleAssignments {
 		role, ok := roleMap[roleAssignment.Role.ID]
 		if !ok {


### PR DESCRIPTION
1) ISSUE: Group name generation in keystone connector for dex token was using customer name from keystone host url.
   Fix: added optional new field customername in keystone config.
  
2) Fixed issue with _  in the domain/tenant names, replacing it with "-"

### TESTING
configured dex with -
```
connectors:
- config:
    domain: default
    customerName: airctl-1-3835425-559
    keystoneHost: http://keystone-internal.airctl-1-3835425-559.svc:5000/keystone
    keystonePassword: <>
    keystoneUsername: <>
  id: default
  name: default
  type: keystone
issuer: https://airctl-1-3835425-559.platform9.localnet/dex
```
dex login worked and the token generated with the group names -
```
  "email": "admin@airctl.localnet",
  "email_verified": true,
  "groups": [
    "airctl-1-3835425-559-default-service-admin",
    "airctl-1-3835425-559-default-service-member",
    "airctl-1-3835425-559-default-service-reader"
  ],
  "name": "admin@airctl.localnet"
```
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Sign a DCO (if you haven't already signed it).
3. Include appropriate tests (if necessary). Make sure that all CI checks passed.
4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

``` 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the keystone connector by removing customerName validation, implementing a dynamic approach to obtain customer names when missing, and adding InsecureSkipVerify configuration. It standardizes group naming by replacing underscores with hyphens for consistency, improving security, flexibility, and maintainability across the system.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>