### PR TITLE
ci: Build and push docker image to quay.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Build and Push Docker Image
+on:
+  push:
+    tags:
+      - "v*"
+      - "publish-image*"
+    branches:
+      - main
+
+env:
+  REGISTRY: quay.io
+  HELM_REGISTRY: quay.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history for all tags and branches. Our image tag generation uses git tags.
+          # We could have just used fetch-tags: true, but alas! This is broken. See:
+          # https://github.com/actions/checkout/issues/1471.
+          #
+          # So for now, we must fetch the full repository.
+          fetch-depth: 0
+
+      - name: Log in to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: List git tags
+        run: git tag -l | tee /dev/stderr
+
+      - name: Debug Git command
+        run: git describe --dirty --tags --match='v*'
+
+      - name: Build Docker image
+        run: make docker-build
+
+      - name: Push Docker image to Quay.io
+        run: make docker-push


### PR DESCRIPTION
Fixes KAAP-908.

<img width="4292" height="3100" alt="CleanShot 2025-08-20 at 13 42 21@2x" src="https://github.com/user-attachments/assets/ea58f212-c535-46a2-9045-beeec46867f6" />

 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the CI pipeline by adding new Docker-related targets in the Makefile. The changes introduce a tagging system that incorporates version, commit count, commit hash, and a dirty flag, ensuring unique image identifiers. These modifications streamline the automation process for building and pushing Docker images.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>